### PR TITLE
ignore unparsed config, fix multiple hosts

### DIFF
--- a/lex.go
+++ b/lex.go
@@ -8,6 +8,7 @@ package sshconfig
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"unicode"
 	"unicode/utf8"
@@ -189,7 +190,8 @@ func lexVariable(l *lexer) stateFn {
 				}
 				return lexValue
 			}
-			return l.errorf("invalid variable: %s", variable)
+			fmt.Fprintf(os.Stderr, "ignoring variable: %s\n", variable)
+			return lexValue
 		default:
 			pattern := l.input[l.start:l.pos]
 			return l.errorf("invalid pattern: %s", pattern)
@@ -201,6 +203,13 @@ func lexHostValue(l *lexer) stateFn {
 	for {
 		switch l.next() {
 		case ' ':
+			switch l.peek() {
+			case '\n', eof:
+				break
+			default:
+				// more coming, wait
+				continue
+			}
 			l.backup()
 			l.emit(itemValue)
 		case '\n':

--- a/lex.go
+++ b/lex.go
@@ -8,7 +8,6 @@ package sshconfig
 
 import (
 	"fmt"
-	"os"
 	"strings"
 	"unicode"
 	"unicode/utf8"
@@ -190,7 +189,6 @@ func lexVariable(l *lexer) stateFn {
 				}
 				return lexValue
 			}
-			fmt.Fprintf(os.Stderr, "ignoring variable: %s\n", variable)
 			return lexValue
 		default:
 			pattern := l.input[l.start:l.pos]

--- a/parser.go
+++ b/parser.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"strconv"
+	"strings"
 )
 
 // SSHHost defines a single host entry in a ssh config
@@ -60,7 +61,8 @@ Loop:
 
 			sshHost = &SSHHost{Host: []string{}, Port: 22}
 		case itemHostValue:
-			sshHost.Host = append(sshHost.Host, token.val)
+			sshHost.Host = strings.Split(token.val, " ")
+
 		case itemHostName:
 			next = lexer.nextItem()
 			if next.typ != itemValue {
@@ -109,7 +111,7 @@ Loop:
 			}
 			break Loop
 		default:
-			return nil, fmt.Errorf(token.val)
+			// continue onwards
 		}
 	}
 	return sshConfigs, nil

--- a/parser.go
+++ b/parser.go
@@ -62,7 +62,6 @@ Loop:
 			sshHost = &SSHHost{Host: []string{}, Port: 22}
 		case itemHostValue:
 			sshHost.Host = strings.Split(token.val, " ")
-
 		case itemHostName:
 			next = lexer.nextItem()
 			if next.typ != itemValue {

--- a/parser_test.go
+++ b/parser_test.go
@@ -1,6 +1,10 @@
 package sshconfig
 
-import "testing"
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
 
 // Test parsing
 func TestParsing(t *testing.T) {
@@ -23,4 +27,91 @@ Host face
 	if err != nil {
 		t.Errorf("unable to parse config: %s", err.Error())
 	}
+}
+
+func TestMultipleHost(t *testing.T) {
+	config := `Host google google2 aws
+  HostName google.se
+  User goog
+  Port 2222`
+
+	hosts, err := parse(config)
+
+	if err != nil {
+		t.Errorf("unable to parse config: %s", err.Error())
+	}
+
+	h := hosts[0]
+	if ok := reflect.DeepEqual([]string{"google", "google2", "aws"}, h.Host); !ok {
+		t.Error("unexpected host mismatch")
+	}
+}
+
+func TestIgnoreKeyword(t *testing.T) {
+	config := `Host google
+  HostName google.se
+  User goog
+  Port 2222
+  ProxyCommand ssh -q pluto nc saturn 22
+  HostKeyAlgorithms ssh-dss
+  # comment
+  IdentityOnly yes
+  IdentityFile ~/.ssh/company
+
+Host face
+  HostName facebook.com
+  User mark
+  Port 22`
+
+	expected := []*SSHHost{
+		{
+			Host:              []string{"google"},
+			HostName:          "google.se",
+			User:              "goog",
+			Port:              2222,
+			HostKeyAlgorithms: "ssh-dss",
+			ProxyCommand:      "ssh -q pluto nc saturn 22",
+			IdentityFile:      "~/.ssh/company",
+		},
+		{
+			Host:              []string{"face"},
+			User:              "mark",
+			Port:              22,
+			HostName:          "facebook.com",
+			HostKeyAlgorithms: "",
+			ProxyCommand:      "",
+			IdentityFile:      "",
+		},
+	}
+	actual, err := parse(config)
+	if err != nil {
+		t.Errorf("unexpected error parsing config: %s", err.Error())
+	}
+
+	compare(t, expected, actual)
+}
+
+func compare(t *testing.T, expected, actual []*SSHHost) {
+	for i, ac := range actual {
+		exMap := toMap(t, expected[i])
+		acMap := toMap(t, ac)
+
+		if ok := reflect.DeepEqual(exMap, acMap); !ok {
+			t.Errorf("unexpected parsed \n expected: %+v \n actual: %+v", exMap, acMap)
+		}
+	}
+}
+
+func toMap(t *testing.T, a *SSHHost) map[string]interface{} {
+	ab, err := json.Marshal(a)
+	if err != nil {
+		t.Errorf("marshaling expected %s", err)
+	}
+
+	var aMap map[string]interface{}
+	if err := json.Unmarshal(ab, &aMap); err != nil {
+		t.Errorf("unmarshaling expected %s", err)
+	}
+
+	return aMap
 }


### PR DESCRIPTION
Fixes: #2, sort of

This PR should fix error when ssh_config contains variables outside the ones specified in `lex.go`. For now I'm just printing to Stderr.

This PR also fixes issue with parsing Host such as `Host host1 host2 other3`, seems like it's incorrectly passing back the first host too soon, and erroring out on the subsequent hosts.