### PR TITLE
update the list of supported items

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Coverage Status](https://coveralls.io/repos/github/mikkeloscar/sshconfig/badge.svg)](https://coveralls.io/github/mikkeloscar/sshconfig)
 
 Parses the config usually found in `~/.ssh/config` or `/etc/ssh/ssh_config`.
-Only `Host`, `HostName`, `User`, `Port` and `ProxyCommand` is implemented at
+Only `Host`, `HostName`, `User`, `Port`, `IdentityFile`, `HostKeyAlgorithms` and `ProxyCommand` is implemented at
 this point.
 
 [OpenSSH Reference.][openssh_man]


### PR DESCRIPTION
all of the attributes defined in the SSHHost struct appear to be parsed
https://github.com/mikkeloscar/sshconfig/blob/master/parser.go#L11