### PR TITLE
infinite parse loop on trailing space

### DIFF
--- a/lex.go
+++ b/lex.go
@@ -208,7 +208,6 @@ func lexHostValue(l *lexer) stateFn {
 				// more coming, wait
 				continue
 			}
-			l.backup()
 			l.emit(itemValue)
 		case '\n':
 			l.backup()

--- a/parser_test.go
+++ b/parser_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"reflect"
 	"testing"
-	"time"
 )
 
 // Test parsing
@@ -57,17 +56,7 @@ func TestTrailingSpace(t *testing.T) {
 Host googlespace 
     HostName google.com
 `
-	sig := make(chan struct{})
-	go func() {
-		parse(config)
-		close(sig)
-	}()
-
-	select {
-	case <-sig:
-	case <-time.After(time.Millisecond * 50):
-		t.Error("timed out parsing")
-	}
+	parse(config)
 }
 
 func TestIgnoreKeyword(t *testing.T) {


### PR DESCRIPTION
Config fails to parse when a Host line has a trailing space, eg `Host google ` <-

The lexer got stuck in a loop returning `itemValue` token with a 0-length string.  Removing a backup when emitting `itemValue` token on whitespace seems to have fixed it and passes the other tests.