### PR TITLE
Add Parse method to read configuration file from a fs.FS

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/mikkeloscar/sshconfig
+
+go 1.16

--- a/parser.go
+++ b/parser.go
@@ -84,17 +84,29 @@ func NewDynamicForward(f string) (DynamicForward, error) {
 	}, nil
 }
 
-// MustParseSSHConfig must parse the SSH config given by path or it will panic
-func MustParseSSHConfig(path string) []*SSHHost {
-	config, err := ParseSSHConfig(path)
+// MustParse must parse the SSH config given by path or it will panic
+func MustParse(path string) []*SSHHost {
+	config, err := Parse(path)
 	if err != nil {
 		panic(err)
 	}
 	return config
 }
 
+// MustParseSSHConfig must parse the SSH config given by path or it will panic
+// Deprecated: Use MustParse instead.
+func MustParseSSHConfig(path string) []*SSHHost {
+	return MustParse(path)
+}
+
 // ParseSSHConfig parses a SSH config given by path.
+// Deprecated: Use Parse instead.
 func ParseSSHConfig(path string) ([]*SSHHost, error) {
+	return Parse(path)
+}
+
+// Parse parses a SSH config given by path.
+func Parse(path string) ([]*SSHHost, error) {
 	// read config file
 	content, err := ioutil.ReadFile(path)
 	if err != nil {
@@ -104,8 +116,8 @@ func ParseSSHConfig(path string) ([]*SSHHost, error) {
 	return parse(string(content))
 }
 
-// Parse parses a SSH config given by path contained in fsys.
-func Parse(fsys fs.FS, path string) ([]*SSHHost, error) {
+// ParseFS parses a SSH config given by path contained in fsys.
+func ParseFS(fsys fs.FS, path string) ([]*SSHHost, error) {
 	// read config file
 	content, err := fs.ReadFile(fsys, path)
 	if err != nil {

--- a/parser.go
+++ b/parser.go
@@ -2,6 +2,7 @@ package sshconfig
 
 import (
 	"fmt"
+	"io/fs"
 	"io/ioutil"
 	"regexp"
 	"strconv"
@@ -96,6 +97,17 @@ func MustParseSSHConfig(path string) []*SSHHost {
 func ParseSSHConfig(path string) ([]*SSHHost, error) {
 	// read config file
 	content, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	return parse(string(content))
+}
+
+// Parse parses a SSH config given by path contained in fsys.
+func Parse(fsys fs.FS, path string) ([]*SSHHost, error) {
+	// read config file
+	content, err := fs.ReadFile(fsys, path)
 	if err != nil {
 		return nil, err
 	}

--- a/parser_test.go
+++ b/parser_test.go
@@ -2,6 +2,8 @@ package sshconfig
 
 import (
 	"encoding/json"
+	"io/ioutil"
+	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -480,6 +482,29 @@ func TestParse(t *testing.T) {
 	Port 22
 	DynamicForward 9223372036854775808`
 
+	ioutil.WriteFile("/tmp/example", []byte(config), os.FileMode(0644))
+
+	actual, err := Parse("/tmp/example")
+
+	var expected []*SSHHost
+
+	expectedErr := "strconv.Atoi: parsing \"9223372036854775808\": value out of range"
+
+	if err == nil || err.Error() != expectedErr {
+		t.Errorf("Did not get expected error: %#v, got %#v", expectedErr, err.Error())
+	}
+
+	compare(t, expected, actual)
+
+}
+
+func TestParseFS(t *testing.T) {
+	config := `Host face
+	HostName facebook.com
+	User mark
+	Port 22
+	DynamicForward 9223372036854775808`
+
 	memfs := fstest.MapFS{
 		"config": &fstest.MapFile{
 			Data: []byte(config),
@@ -500,7 +525,7 @@ func TestParse(t *testing.T) {
 
 }
 
-func TestParseNonExitentFile(t *testing.T) {
+func TestParseFSNonExitentFile(t *testing.T) {
 	memfs := fstest.MapFS{}
 
 	_, err := ParseFS(memfs, "config")

--- a/parser_test.go
+++ b/parser_test.go
@@ -486,7 +486,7 @@ func TestParse(t *testing.T) {
 		},
 	}
 
-	actual, err := Parse(memfs, "config")
+	actual, err := ParseFS(memfs, "config")
 
 	var expected []*SSHHost
 
@@ -503,7 +503,7 @@ func TestParse(t *testing.T) {
 func TestParseNonExitentFile(t *testing.T) {
 	memfs := fstest.MapFS{}
 
-	_, err := Parse(memfs, "config")
+	_, err := ParseFS(memfs, "config")
 
 	expectedErr := "open config: file does not exist"
 


### PR DESCRIPTION
The new introduced method introduce the possibility to parse configuration
using the new `fs` package introduced in Go 1.16.

A useful use case could be to use an embedded configuration file.