### PR TITLE
Add support to `Include` directive

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/mikkeloscar/sshconfig
 
 go 1.16
+
+require github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
+github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=

--- a/lex.go
+++ b/lex.go
@@ -51,6 +51,7 @@ const (
 	itemLocalForward
 	itemRemoteForward
 	itemDynamicForward
+	itemInclude
 )
 
 // variables
@@ -65,6 +66,7 @@ var variables = map[string]itemType{
 	"localforward":      itemLocalForward,
 	"remoteforward":     itemRemoteForward,
 	"dynamicforward":    itemDynamicForward,
+	"include":           itemInclude,
 }
 
 const eof = -1

--- a/parser.go
+++ b/parser.go
@@ -4,9 +4,12 @@ import (
 	"fmt"
 	"io/fs"
 	"io/ioutil"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
+
+	"github.com/mitchellh/go-homedir"
 )
 
 // SSHHost defines a single host entry in a ssh config
@@ -113,7 +116,7 @@ func Parse(path string) ([]*SSHHost, error) {
 		return nil, err
 	}
 
-	return parse(string(content))
+	return parse(string(content), path)
 }
 
 // ParseFS parses a SSH config given by path contained in fsys.
@@ -124,11 +127,11 @@ func ParseFS(fsys fs.FS, path string) ([]*SSHHost, error) {
 		return nil, err
 	}
 
-	return parse(string(content))
+	return parse(string(content), path)
 }
 
 // parses an openssh config file
-func parse(input string) ([]*SSHHost, error) {
+func parse(input string, path string) ([]*SSHHost, error) {
 	sshConfigs := []*SSHHost{}
 	var next item
 	var sshHost *SSHHost
@@ -138,8 +141,12 @@ Loop:
 	for {
 		token := lexer.nextItem()
 
-		if sshHost == nil && token.typ != itemHost {
-			return nil, fmt.Errorf("config variable before Host variable")
+		if sshHost == nil {
+			if token.typ != itemEOF && token.typ != itemHost && token.typ != itemInclude {
+				return nil, fmt.Errorf("%s:%d: config variable before Host variable", path, token.pos)
+			}
+		} else if token.typ == itemInclude {
+			return nil, fmt.Errorf("include not allowed in Host block")
 		}
 
 		switch token.typ {
@@ -212,6 +219,38 @@ Loop:
 				return nil, err
 			}
 			sshHost.DynamicForwards = append(sshHost.DynamicForwards, f)
+		case itemInclude:
+			next = lexer.nextItem()
+			if next.typ != itemValue {
+				return nil, fmt.Errorf(next.val)
+			}
+
+			includePath := next.val
+
+			if strings.HasPrefix(includePath, "~") {
+				expandedPath, err := homedir.Expand(includePath)
+				if err != nil {
+					return nil, err
+				}
+
+				includePath = expandedPath
+			} else if !strings.HasPrefix(includePath, "/") {
+				includePath = filepath.Join(filepath.Dir(path), next.val)
+			}
+
+			files, err := filepath.Glob(includePath)
+			if err != nil {
+				return nil, err
+			}
+
+			for _, f := range files {
+				includeSshConfigs, err := Parse(f)
+				if err != nil {
+					return nil, err
+				}
+
+				sshConfigs = append(sshConfigs, includeSshConfigs...)
+			}
 		case itemError:
 			return nil, fmt.Errorf("%s at pos %d", token.val, token.pos)
 		case itemEOF:

--- a/parser.go
+++ b/parser.go
@@ -235,6 +235,10 @@ Loop:
 				return nil, err
 			}
 
+			if len(files) == 0 {
+				return nil, fmt.Errorf("no files found for include path %s", includePath)
+			}
+
 			for _, f := range files {
 				includeSshConfigs, err := Parse(f)
 				if err != nil {

--- a/parser.go
+++ b/parser.go
@@ -225,17 +225,9 @@ Loop:
 				return nil, fmt.Errorf(next.val)
 			}
 
-			includePath := next.val
-
-			if strings.HasPrefix(includePath, "~") {
-				expandedPath, err := homedir.Expand(includePath)
-				if err != nil {
-					return nil, err
-				}
-
-				includePath = expandedPath
-			} else if !strings.HasPrefix(includePath, "/") {
-				includePath = filepath.Join(filepath.Dir(path), next.val)
+			includePath, err := parseIncludePath(path, next.val)
+			if err != nil {
+				return nil, err
 			}
 
 			files, err := filepath.Glob(includePath)
@@ -263,4 +255,19 @@ Loop:
 		}
 	}
 	return sshConfigs, nil
+}
+
+func parseIncludePath(currentPath string, includePath string) (string, error) {
+	if strings.HasPrefix(includePath, "~") {
+		expandedPath, err := homedir.Expand(includePath)
+		if err != nil {
+			return "", err
+		}
+
+		return expandedPath, nil
+	} else if !strings.HasPrefix(includePath, "/") {
+		return filepath.Join(filepath.Dir(currentPath), includePath), nil
+	}
+
+	return includePath, nil
 }

--- a/parser_test.go
+++ b/parser_test.go
@@ -26,7 +26,7 @@ Host face
   User mark
   Port 22`
 
-	_, err := parse(config)
+	_, err := parse(config, "~/.ssh/config")
 
 	if err != nil {
 		t.Errorf("unable to parse config: %s", err.Error())
@@ -46,7 +46,7 @@ Host face
   User mark
   Port 22`, "\n", "\r\n", -1)
 
-	_, err = parse(configCR)
+	_, err = parse(configCR, "~/.ssh/config")
 
 	if err != nil {
 		t.Errorf("unable to parse config: %s", err.Error())
@@ -55,7 +55,7 @@ Host face
 
 func TestTrailingComment(t *testing.T) {
 	config := "Host *\n#comment"
-	_, err := parse(config)
+	_, err := parse(config, "~/.ssh/config")
 	if err != nil {
 		t.Errorf("unable to parse config: %s", err.Error())
 	}
@@ -67,7 +67,7 @@ func TestMultipleHost(t *testing.T) {
   User goog
   Port 2222`
 
-	hosts, err := parse(config)
+	hosts, err := parse(config, "~/.ssh/config")
 
 	if err != nil {
 		t.Errorf("unable to parse config: %s", err.Error())
@@ -88,7 +88,7 @@ func TestTrailingSpace(t *testing.T) {
 Host googlespace 
     HostName google.com
 `
-	parse(config)
+	parse(config, "~/.ssh/config")
 }
 
 func TestIgnoreKeyword(t *testing.T) {
@@ -127,7 +127,7 @@ Host face
 			IdentityFile:      "",
 		},
 	}
-	actual, err := parse(config)
+	actual, err := parse(config, "~/.ssh/config")
 	if err != nil {
 		t.Errorf("unexpected error parsing config: %s", err.Error())
 	}
@@ -196,7 +196,7 @@ Host face
 			},
 		},
 	}
-	actual, err := parse(config)
+	actual, err := parse(config, "~/.ssh/config")
 	if err != nil {
 		t.Errorf("unexpected error parsing config: %s", err.Error())
 	}
@@ -215,7 +215,7 @@ func TestLocalForwardInvalid1(t *testing.T) {
 
 	expectedErr := "Invalid forward: \"2222 totalylegitserver 22\""
 
-	actual, err := parse(config)
+	actual, err := parse(config, "~/.ssh/config")
 	if err == nil || err.Error() != expectedErr {
 		t.Errorf("Did not get expected error: %#v, got %#v", expectedErr, err.Error())
 	}
@@ -234,7 +234,7 @@ func TestLocalForwardInvalid2(t *testing.T) {
 
 	expectedErr := "strconv.Atoi: parsing \"9223372036854775808\": value out of range"
 
-	actual, err := parse(config)
+	actual, err := parse(config, "~/.ssh/config")
 	if err == nil || err.Error() != expectedErr {
 		t.Errorf("Did not get expected error: %#v, got %#v", expectedErr, err.Error())
 	}
@@ -253,7 +253,7 @@ func TestLocalForwardInvalid3(t *testing.T) {
 
 	expectedErr := "strconv.Atoi: parsing \"9223372036854775808\": value out of range"
 
-	actual, err := parse(config)
+	actual, err := parse(config, "~/.ssh/config")
 	if err == nil || err.Error() != expectedErr {
 		t.Errorf("Did not get expected error: %#v, got %#v", expectedErr, err.Error())
 	}
@@ -322,7 +322,7 @@ Host face
 			},
 		},
 	}
-	actual, err := parse(config)
+	actual, err := parse(config, "~/.ssh/config")
 	if err != nil {
 		t.Errorf("unexpected error parsing config: %s", err.Error())
 	}
@@ -341,7 +341,7 @@ func TestRemoteForwardInvalid1(t *testing.T) {
 
 	expectedErr := "Invalid forward: \"abc totalylegitserver:22\""
 
-	actual, err := parse(config)
+	actual, err := parse(config, "~/.ssh/config")
 	if err == nil || err.Error() != expectedErr {
 		t.Errorf("Did not get expected error: %#v, got %#v", expectedErr, err.Error())
 	}
@@ -404,7 +404,7 @@ Host face
 			},
 		},
 	}
-	actual, err := parse(config)
+	actual, err := parse(config, "~/.ssh/config")
 	if err != nil {
 		t.Errorf("unexpected error parsing config: %s", err.Error())
 	}
@@ -423,7 +423,7 @@ func TestDynamicForward1(t *testing.T) {
 
 	expectedErr := "Invalid dynamic forward: \"abc\""
 
-	actual, err := parse(config)
+	actual, err := parse(config, "~/.ssh/config")
 	if err == nil || err.Error() != expectedErr {
 		t.Errorf("Did not get expected error: %#v, got %#v", expectedErr, err.Error())
 	}
@@ -442,7 +442,7 @@ func TestDynamicForward2(t *testing.T) {
 
 	expectedErr := "strconv.Atoi: parsing \"9223372036854775808\": value out of range"
 
-	actual, err := parse(config)
+	actual, err := parse(config, "~/.ssh/config")
 	if err == nil || err.Error() != expectedErr {
 		t.Errorf("Did not get expected error: %#v, got %#v", expectedErr, err.Error())
 	}


### PR DESCRIPTION
There is an [issue](https://github.com/quantumsheep/sshs/issues/1) where using `Include` in ssh config files cause the parsing to fail. This is due to the `Include` directive not being implemented yet.

This introduces parsing and handling of `Include` directives.