### PR TITLE
Add Ciphers and MACs fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Coverage Status](https://coveralls.io/repos/github/mikkeloscar/sshconfig/badge.svg)](https://coveralls.io/github/mikkeloscar/sshconfig)
 
 Parses the config usually found in `~/.ssh/config` or `/etc/ssh/ssh_config`.
-Only `Host`, `HostName`, `User`, `Port`, `IdentityFile`, `HostKeyAlgorithms`, `ProxyCommand`, `LocalForward`, `RemoteForward` and `DynamicForward` is implemented at
+Only `Host`, `HostName`, `User`, `Port`, `IdentityFile`, `HostKeyAlgorithms`, `ProxyCommand`, `LocalForward`, `RemoteForward`, `DynamicForward`, `Ciphers` and `MACs` is implemented at
 this point.
 
 [OpenSSH Reference.][openssh_man]

--- a/lex.go
+++ b/lex.go
@@ -52,6 +52,8 @@ const (
 	itemRemoteForward
 	itemDynamicForward
 	itemInclude
+	itemCiphers
+	itemMACs
 )
 
 // variables
@@ -67,6 +69,8 @@ var variables = map[string]itemType{
 	"remoteforward":     itemRemoteForward,
 	"dynamicforward":    itemDynamicForward,
 	"include":           itemInclude,
+	"ciphers":           itemCiphers,
+	"macs":              itemMACs,
 }
 
 const eof = -1

--- a/parser.go
+++ b/parser.go
@@ -24,6 +24,8 @@ type SSHHost struct {
 	LocalForwards     []Forward
 	RemoteForwards    []Forward
 	DynamicForwards   []DynamicForward
+	Ciphers           []string
+	MACs              []string
 }
 
 // Forward defines a single port forward entry
@@ -247,6 +249,18 @@ Loop:
 
 				sshConfigs = append(sshConfigs, includeSshConfigs...)
 			}
+		case itemCiphers:
+			next = lexer.nextItem()
+			if next.typ != itemValue {
+				return nil, fmt.Errorf(next.val)
+			}
+			sshHost.Ciphers = strings.Split(next.val, ",")
+		case itemMACs:
+			next = lexer.nextItem()
+			if next.typ != itemValue {
+				return nil, fmt.Errorf(next.val)
+			}
+			sshHost.MACs = strings.Split(next.val, ",")
 		case itemError:
 			return nil, fmt.Errorf("%s at pos %d", token.val, token.pos)
 		case itemEOF:

--- a/parser_test.go
+++ b/parser_test.go
@@ -24,6 +24,9 @@ func TestParsing(t *testing.T) {
   HostKeyAlgorithms ssh-dss
   # comment
   IdentityFile ~/.ssh/company
+  Ciphers aes256-ctr,aes128-cbc
+  MACs hmac-md5,hmac-sha2-256
+
 
 Host face
   HostName facebook.com
@@ -109,7 +112,15 @@ func TestIgnoreKeyword(t *testing.T) {
 Host face
   HostName facebook.com
   User mark
-  Port 22`
+  Port 22
+
+Host other
+  HostName example.org
+  User root
+  Port 22
+  Ciphers 3des-cbc,blowfish-cbc,cast128-cbc
+  MACs hmac-sha1,hmac-sha1-96
+  `
 
 	expected := []*SSHHost{
 		{
@@ -129,6 +140,14 @@ Host face
 			HostKeyAlgorithms: "",
 			ProxyCommand:      "",
 			IdentityFile:      "",
+		},
+		{
+			Host:     []string{"other"},
+			User:     "root",
+			Port:     22,
+			HostName: "example.org",
+			Ciphers:  []string{"3des-cbc", "blowfish-cbc", "cast128-cbc"},
+			MACs:     []string{"hmac-sha1", "hmac-sha1-96"},
 		},
 	}
 	actual, err := parse(config, "~/.ssh/config")


### PR DESCRIPTION
Adding to new fields to the parser: Ciphers and MACs. This feature will be used in a tool called [sup](https://github.com/pressly/sup) (it uses sshconfig already but lacks support for these two fields to succesfuly connect to old hardware like old cisco routers or synology NAS).
