### PR TITLE
fix: Error on file without Host declaration.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/mikkeloscar/sshconfig
+module github.com/userwiths/sshconfig
 
 go 1.21
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/userwiths/sshconfig
+module github.com/mikkeloscar/sshconfig
 
 go 1.21
 

--- a/parser.go
+++ b/parser.go
@@ -137,7 +137,7 @@ func parse(input string, path string) ([]*SSHHost, error) {
 	sshConfigs := []*SSHHost{}
 	var next item
 	var sshHost *SSHHost
-	var onlyIncludes bool = !strings.Contains(input, "Host") && strings.Contains(input, "Include");
+	var onlyIncludes bool = !strings.Contains(input, "Host ") && strings.Contains(input, "Include ");
 
 	lexer := lex(input)
 Loop:
@@ -146,12 +146,12 @@ Loop:
 
 		if sshHost == nil {
 			if token.typ == itemEOF {
-				break
+				break Loop
 			}
 			if token.typ != itemHost && token.typ != itemInclude {
 				// File has no `Host` but has `Include`. Continue trying to parse it.
 				if  onlyIncludes {
-					continue
+					continue Loop
 				}
 				return nil, fmt.Errorf("%s:%d: config variable before Host variable", path, token.pos)
 			}

--- a/parser.go
+++ b/parser.go
@@ -137,7 +137,7 @@ func parse(input string, path string) ([]*SSHHost, error) {
 	sshConfigs := []*SSHHost{}
 	var next item
 	var sshHost *SSHHost
-	var onlyIncludes bool = !input.Contains("Host") && input.Contains("Include");
+	var onlyIncludes bool = !strings.Contains(input, "Host") && strings.Contains(input, "Include");
 
 	lexer := lex(input)
 Loop:

--- a/parser_test.go
+++ b/parser_test.go
@@ -691,3 +691,48 @@ func TestParseFSNonExitentFile(t *testing.T) {
 	}
 
 }
+
+func TestHostlessFile(t *testing.T) {
+	config := `Include ./b.conf
+	Include ./a.conf
+	VisualHostKey yes`
+
+	configB := `Host google
+	  HostName google.se
+	  User goog
+	  Port 2222`
+	configA := `Host face
+	  HostName facebook.com
+	  User mark
+	  Port 22`
+
+	tmpdir := t.TempDir()
+
+	f, err := os.Create(tmpdir + "/b.conf")
+	if err != nil {
+		t.Errorf("unable to create file: %s", err.Error())
+	}
+	defer f.Close()
+
+	_, err = f.WriteString(configB)
+	if err != nil {
+		t.Errorf("unable to write to file: %s", err.Error())
+	}
+
+	f, err = os.Create(tmpdir + "/a.conf")
+	if err != nil {
+		t.Errorf("unable to create file: %s", err.Error())
+	}
+	defer f.Close()
+
+	_, err = f.WriteString(configA)
+	if err != nil {
+		t.Errorf("unable to write to file: %s", err.Error())
+	}
+
+	_, err = parse(config, tmpdir + "/config")
+
+	if err != nil {
+		t.Errorf("unable to parse config: %s", err.Error())
+	}
+}


### PR DESCRIPTION
Hello there.

Current PR is open because of a behavior I've met while using [sshs](https://github.com/quantumsheep/sshs) and it can be seen in [this short Issue](https://github.com/quantumsheep/sshs/issues/55)

It happens when the main config file (as far as I can tell) contains only includes and global options, no `Host` declarations as they are inside the includes. In this case it does not matter the position of the global option as it always results in the same error, because there is not a single `Host` in the file.

Ive also moved the `EOF` condition as a `break` condition. I can revert that if you wish, but I believe it makes sense to exit if we meet `EOF` instead of throw an error.

The new condition I added checks if the `input`/content contains only `Include`s and in case it does, it attempts to work through the end of the file in order to expand/parse all Includes before exiting.

I've tested it locally and verified that if a global setting is put before a `Host` declaration the behavior remains the same and we get the error message.