### PR TITLE
Issue 14: Wildcard hosts

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/mikkeloscar/sshconfig
+module github.com/userwiths/sshconfig
 
 go 1.21
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/userwiths/sshconfig
+module github.com/mikkeloscar/sshconfig
 
 go 1.21
 

--- a/parser.go
+++ b/parser.go
@@ -301,10 +301,11 @@ Loop:
 
 func applyWildcardRules(wildcardHosts []*SSHHost, sshConfigs []*SSHHost) ([]*SSHHost, error) {
 	for _, wildcardHost := range wildcardHosts {
+		HostLoop:
 		for _, host := range sshConfigs {
 			matched := matchWildcardHost(wildcardHost, host)
 			if !matched {
-				break
+				continue HostLoop
 			}
 			err := mergeSSHConfigs(wildcardHost, host)
 			if err != nil {
@@ -318,7 +319,7 @@ func applyWildcardRules(wildcardHosts []*SSHHost, sshConfigs []*SSHHost) ([]*SSH
 func matchWildcardHost(wildcardHost *SSHHost, host *SSHHost) bool {
 	for _, h := range wildcardHost.Host {
 		for _, hh := range host.Host {
-			regexpHost := strings.Replace(h, "*", ".*", -1)
+			regexpHost := "^" + strings.Replace(h, "*", ".*", -1) + "$"
 			matched, err := regexp.MatchString(regexpHost, hh)
 			if matched {
 				return true

--- a/parser_test.go
+++ b/parser_test.go
@@ -695,7 +695,7 @@ func TestParseFSNonExitentFile(t *testing.T) {
 func TestWildcardHost(t *testing.T) {
 	config := `Host *
   User mark
-  Port 22
+  Port 222
   Host empty
   HostName empty.com
   Host onlyport
@@ -706,7 +706,7 @@ func TestWildcardHost(t *testing.T) {
 		{
 			Host: []string{"empty"},
 			User: "mark",
-			Port: 22,
+			Port: 222,
 			HostName: "empty.com",
 		}, {
 			Host: []string{"onlyport"},
@@ -715,7 +715,7 @@ func TestWildcardHost(t *testing.T) {
 		}, {
 			Host: []string{"onlyuser"},
 			User: "onlyuser",
-			Port: 22,
+			Port: 222,
 		},
 	}
 	parsed, err := parse(config, "~/.ssh/config")

--- a/parser_test.go
+++ b/parser_test.go
@@ -691,3 +691,39 @@ func TestParseFSNonExitentFile(t *testing.T) {
 	}
 
 }
+
+func TestWildcardHost(t *testing.T) {
+	config := `Host *
+  User mark
+  Port 22
+  Host empty
+  HostName empty.com
+  Host onlyport
+  Port 2222
+  Host onlyuser
+  User onlyuser`
+	expected := []*SSHHost{
+		{
+			Host: []string{"empty"},
+			User: "mark",
+			Port: 22,
+			HostName: "empty.com",
+		}, {
+			Host: []string{"onlyport"},
+			User: "mark",
+			Port: 2222,
+		}, {
+			Host: []string{"onlyuser"},
+			User: "onlyuser",
+			Port: 22,
+		},
+	}
+	parsed, err := parse(config, "~/.ssh/config")
+	if err != nil {
+		t.Errorf("unexpected error parsing config: %s", err.Error())
+	}
+	compare(t, expected, parsed)
+}
+
+
+	


### PR DESCRIPTION
Issue: #14 
Currently this PR is marked as draft, because I'd love to clear out the `TODO` at the bottom and probably address requests from reviews if there are such.

Still I've tested this locally and at the moment it suits my (rather basic) needs well.

Here is a quick outline of the made changes:

## Changes

* Removed [hardcoded default port](https://github.com/mikkeloscar/sshconfig/blob/25c825e0c9656754d89d46624fbb6f54064279a4/parser.go#L160), because of it, there was no way to tell if the `Port` value is read from config or if we are using the hardcoded one.
* Instead, before returning the `sshConfigs` array, we cycle through it and in case the `Port` is `0` (the default one) we set it to `22`.
* We keep a list of wildcard hosts in `wildcardHosts` variable. Where we were adding the host to the config, now we do additional check to see if it is an actual host or a wildcard one. If it is wildcard it goes in to the new variable.
* After we have parsed/read the config, we check if we have any `wildcardHosts` added. If we have we call `applyWildcardRules` with the hosts and wildcard hosts.
    * Note: This call **can** return an error on theory, I tried to handle them all but still.
* We try to match the `Host` values using regex in the form of `^wildcard$` where wildcard is the `Host` value with `*` replaced with `.*`.
* If we get a match we apply the wildcard by calling `mergeSSHConfigs`.
    * The function returns `nil` on success and `Error` otherwise.
    * It uses reflection to go through the fields of the structure, because otherwise we would have to do another **BIG** block of `if`/`else` conditions and I try to not do that.
    * We apply the value from the wildcard **ONLY** if there is no other value in place atm (thats the reason the default port was moved after this operation).
* There four tests `TestMultiWildcard`, `TestUnmatchedWildcardBetween`, `TestUnmatchedWildcardPrefix`, `TestUnmatchedWildcardPost`. Each of them tests a different placement of the wildcard and one of them tests multiple wildcards.


## TODO
* `LocalForwards`, `RemoteForwards`, `DynamicForwards` - Currently we do not handle those. Might need to implement them specifically and not use reflection, must check.
* `Ciphers`, `MACs` - First attempt at using reflection to add to a string array failed. Either read/try a bit more to make it work or do not use reflection, must check.
* At the moment wildcard hosts should work on single file level. If you have a wildcard host inside an `Include`ed file, it will be applied only to hosts inside this include.