### PR TITLE
Add support for proxy jump

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Coverage Status](https://coveralls.io/repos/github/mikkeloscar/sshconfig/badge.svg)](https://coveralls.io/github/mikkeloscar/sshconfig)
 
 Parses the config usually found in `~/.ssh/config` or `/etc/ssh/ssh_config`.
-Only `Host`, `HostName`, `User`, `Port`, `IdentityFile`, `HostKeyAlgorithms`, `ProxyCommand`, `LocalForward`, `RemoteForward`, `DynamicForward`, `Ciphers` and `MACs` is implemented at
+Only `Host`, `HostName`, `User`, `Port`, `IdentityFile`, `HostKeyAlgorithms`, `ProxyCommand`, `ProxyJump`, `LocalForward`, `RemoteForward`, `DynamicForward`, `Ciphers` and `MACs` is implemented at
 this point.
 
 [OpenSSH Reference.][openssh_man]

--- a/lex.go
+++ b/lex.go
@@ -46,6 +46,7 @@ const (
 	itemUser
 	itemPort
 	itemProxyCommand
+	itemProxyJumpHost
 	itemHostKeyAlgorithms
 	itemIdentityFile
 	itemLocalForward
@@ -63,6 +64,7 @@ var variables = map[string]itemType{
 	"user":              itemUser,
 	"port":              itemPort,
 	"proxycommand":      itemProxyCommand,
+	"proxyjump":         itemProxyJumpHost,
 	"hostkeyalgorithms": itemHostKeyAlgorithms,
 	"identityfile":      itemIdentityFile,
 	"localforward":      itemLocalForward,


### PR DESCRIPTION
This pr adds support for `ProxyJump`, I'am using this library to parse ssh config and parsing ProxyCommand for ssh connections over some proxy machine. It would be nice to support also ProxyJump, as usually that is used instead of ProxyCommand