### PR TITLE
Added IdentityAgent directive support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Coverage Status](https://coveralls.io/repos/github/mikkeloscar/sshconfig/badge.svg)](https://coveralls.io/github/mikkeloscar/sshconfig)
 
 Parses the config usually found in `~/.ssh/config` or `/etc/ssh/ssh_config`.
-Only `Host`, `HostName`, `User`, `Port`, `IdentityFile`, `HostKeyAlgorithms`, `ProxyCommand`, `ProxyJump`, `LocalForward`, `RemoteForward`, `DynamicForward`, `Ciphers` and `MACs` is implemented at
+Only `Host`, `HostName`, `User`, `Port`, `IdentityFile`, `IdentityAgent`, `HostKeyAlgorithms`, `ProxyCommand`, `ProxyJump`, `LocalForward`, `RemoteForward`, `DynamicForward`, `Ciphers` and `MACs` is implemented at
 this point.
 
 [OpenSSH Reference.][openssh_man]

--- a/lex.go
+++ b/lex.go
@@ -49,6 +49,7 @@ const (
 	itemProxyJumpHost
 	itemHostKeyAlgorithms
 	itemIdentityFile
+	itemIdentityAgent
 	itemLocalForward
 	itemRemoteForward
 	itemDynamicForward
@@ -67,6 +68,7 @@ var variables = map[string]itemType{
 	"proxyjump":         itemProxyJumpHost,
 	"hostkeyalgorithms": itemHostKeyAlgorithms,
 	"identityfile":      itemIdentityFile,
+	"identityagent":     itemIdentityAgent,
 	"localforward":      itemLocalForward,
 	"remoteforward":     itemRemoteForward,
 	"dynamicforward":    itemDynamicForward,

--- a/parser.go
+++ b/parser.go
@@ -22,6 +22,7 @@ type SSHHost struct {
 	ProxyJump         []string
 	HostKeyAlgorithms string
 	IdentityFile      string
+	IdentityAgent     string
 	LocalForwards     []Forward
 	RemoteForwards    []Forward
 	DynamicForwards   []DynamicForward
@@ -215,6 +216,12 @@ Loop:
 				return nil, fmt.Errorf(next.val)
 			}
 			sshHost.IdentityFile = next.val
+		case itemIdentityAgent:
+			next = lexer.nextItem()
+			if next.typ != itemValue {
+				return nil, fmt.Errorf(next.val)
+			}
+			sshHost.IdentityAgent = next.val
 		case itemLocalForward:
 			next = lexer.nextItem()
 			f, err := NewForward(next.val)

--- a/parser_test.go
+++ b/parser_test.go
@@ -23,6 +23,7 @@ func TestParsing(t *testing.T) {
   HostKeyAlgorithms ssh-dss
   # comment
   IdentityFile ~/.ssh/company
+  IdentityAgent /dummy/agent.sock
   Ciphers aes256-ctr,aes128-cbc
   MACs hmac-md5,hmac-sha2-256
 
@@ -112,6 +113,7 @@ func TestIgnoreKeyword(t *testing.T) {
   # comment
   IdentityOnly yes
   IdentityFile ~/.ssh/company
+  IdentityAgent /dummy/agent.sock
 
 Host face
   HostName facebook.com
@@ -136,6 +138,7 @@ Host other
 			HostKeyAlgorithms: "ssh-dss",
 			ProxyCommand:      "ssh -q pluto nc saturn 22",
 			IdentityFile:      "~/.ssh/company",
+			IdentityAgent:     "/dummy/agent.sock",
 		},
 		{
 			Host:              []string{"face"},


### PR DESCRIPTION
very small PR just to support IdentityAgent option (needed to read 1password custom agent socket)
[docs](https://man.openbsd.org/cgi-bin/man.cgi/OpenBSD-current/man5/ssh_config.5?query=ssh_config&sec=5#IdentityAgent)